### PR TITLE
Multiple categories for [staff-directory] shortcode with slug.

### DIFF
--- a/classes/staff_directory_shortcode.php
+++ b/classes/staff_directory_shortcode.php
@@ -86,6 +86,9 @@ class StaffDirectoryShortcode {
 					break;
 			}
 		}
+		else {
+			$output = '';
+		}
 
 		wp_reset_query();
 

--- a/classes/staff_directory_shortcode.php
+++ b/classes/staff_directory_shortcode.php
@@ -73,17 +73,18 @@ class StaffDirectoryShortcode {
 
 		$staff_query = new WP_Query( $query_args );
 
-		switch ( $template ) {
-			case 'list':
-				$output = StaffDirectoryShortcode::html_for_list_template( $staff_query );
-				break;
-			case 'grid':
-				$output = StaffDirectoryShortcode::html_for_grid_template( $staff_query );
-				break;
-			default:
-				$output = StaffDirectoryShortcode::html_for_custom_template( $template, $staff_query );
-				break;
-
+		if ($wp_query->have_posts()) {
+			switch ( $template ) {
+				case 'list':
+					$output = StaffDirectoryShortcode::html_for_list_template( $staff_query );
+					break;
+				case 'grid':
+					$output = StaffDirectoryShortcode::html_for_grid_template( $staff_query );
+					break;
+				default:
+					$output = StaffDirectoryShortcode::html_for_custom_template( $template, $staff_query );
+					break;
+			}
 		}
 
 		wp_reset_query();

--- a/classes/staff_directory_shortcode.php
+++ b/classes/staff_directory_shortcode.php
@@ -73,7 +73,7 @@ class StaffDirectoryShortcode {
 
 		$staff_query = new WP_Query( $query_args );
 
-		if ($wp_query->have_posts()) {
+		if ( $staff_query->have_posts() ) {
 			switch ( $template ) {
 				case 'list':
 					$output = StaffDirectoryShortcode::html_for_list_template( $staff_query );

--- a/classes/staff_directory_shortcode.php
+++ b/classes/staff_directory_shortcode.php
@@ -54,7 +54,9 @@ class StaffDirectoryShortcode {
 			$query_args['tax_query'] = array(
 				array(
 					'taxonomy' => 'staff_category',
-					'terms'    => array( $cat )
+					'terms'    => explode( ',', $cat ),
+					'field'    => 'slug',
+					'operator' => 'AND'
 				)
 			);
 		}


### PR DESCRIPTION
Multiple category support for [staff-directory] shortcode (eg. [staff-directory cat="slug1,slug2"]), resulting in the intersection of staff having all the categories specified.
Keep in mind that to ease the use of the shortcode it supports only category slugs, not ids.
