### PR TITLE
Change use of empty() to test for false

### DIFF
--- a/classes/staff-directory-shortcode.php
+++ b/classes/staff-directory-shortcode.php
@@ -88,7 +88,7 @@ class Staff_Directory_Shortcode {
     }
 
     static function photo_shortcode(){
-        if(!empty(self::photo_url_shortcode())){
+        if(self::photo_url_shortcode() == false){
             return '<img src="' . self::photo_url_shortcode() . '" />';
         } else {
             return "";


### PR DESCRIPTION
Prior to PHP 5.5 empty() only supported variables. For those still on pre-5.5 I have changed it to test for false instead of using empty().