### PR TITLE
Internationalization support

### DIFF
--- a/classes/staff-directory.php
+++ b/classes/staff-directory.php
@@ -9,7 +9,6 @@ class Staff_Directory {
 	static function register_post_types() {
 		add_action( 'init', array( 'Staff_Directory', 'create_post_types' ) );
 		add_action( 'init', array( 'Staff_Directory', 'create_staff_taxonomies' ) );
-		add_action( 'init', array( 'Staff_Directory', 'load_textdomain' ) );
 		add_filter( "manage_edit-staff_columns", array( 'Staff_Directory', 'set_staff_admin_columns' ) );
 		add_filter( "manage_staff_posts_custom_column", array(
 			'Staff_Directory',
@@ -40,7 +39,7 @@ class Staff_Directory {
 		register_post_type( 'staff',
 			array(
 				'labels'     => array(
-					'name' => __( 'Staff' )
+					'name' => __( 'Staff', 'staff-directory' )
 				),
 				'supports'   => array(
 					'title',
@@ -58,17 +57,17 @@ class Staff_Directory {
 		register_taxonomy( 'staff_category', 'staff', array(
 			'hierarchical' => true,
 			'labels'       => array(
-				'name'              => _x( 'Staff Category', 'taxonomy general name' ),
-				'singular_name'     => _x( 'staff-category', 'taxonomy singular name' ),
-				'search_items'      => __( 'Search Staff Categories' ),
-				'all_items'         => __( 'All Staff Categories' ),
-				'parent_item'       => __( 'Parent Staff Category' ),
-				'parent_item_colon' => __( 'Parent Staff Category:' ),
-				'edit_item'         => __( 'Edit Staff Category' ),
-				'update_item'       => __( 'Update Staff Category' ),
-				'add_new_item'      => __( 'Add New Staff Category' ),
-				'new_item_name'     => __( 'New Staff Category Name' ),
-				'menu_name'         => __( 'Staff Categories' ),
+				'name'              => _x( 'Staff Category', 'taxonomy general name', 'staff-directory' ),
+				'singular_name'     => _x( 'staff-category', 'taxonomy singular name', 'staff-directory' ),
+				'search_items'      => __( 'Search Staff Categories', 'staff-directory' ),
+				'all_items'         => __( 'All Staff Categories', 'staff-directory' ),
+				'parent_item'       => __( 'Parent Staff Category', 'staff-directory' ),
+				'parent_item_colon' => __( 'Parent Staff Category:', 'staff-directory' ),
+				'edit_item'         => __( 'Edit Staff Category', 'staff-directory' ),
+				'update_item'       => __( 'Update Staff Category', 'staff-directory' ),
+				'add_new_item'      => __( 'Add New Staff Category', 'staff-directory' ),
+				'new_item_name'     => __( 'New Staff Category Name', 'staff-directory' ),
+				'menu_name'         => __( 'Staff Categories', 'staff-directory' ),
 			),
 			'rewrite'      => array(
 				'slug'         => 'staff-categories',
@@ -79,7 +78,7 @@ class Staff_Directory {
 	}
 
 	static function load_textdomain() {
-		load_plugin_textdomain('staff-directory', false, basename(dirname(__FILE__)) . '/languages/');
+		load_plugin_textdomain('staff-directory', false, STAFF_LANGUAGES_DIRECTORY);
 	}
 
     static function load_profile_template($original){
@@ -108,10 +107,10 @@ class Staff_Directory {
 	static function set_staff_admin_columns() {
 		$new_columns = array(
 			'cb'             => '<input type="checkbox" />',
-			'title'          => __( 'Title' ),
-			'id'             => __( 'ID' ),
-			'featured_image' => __( 'Featured Image' ),
-			'date'           => __( 'Date' )
+			'title'          => __( 'Title', 'staff-directory' ),
+			'id'             => __( 'ID', 'staff-directory' ),
+			'featured_image' => __( 'Featured Image', 'staff-directory' ),
+			'date'           => __( 'Date', 'staff-directory' )
 		);
 
 		return $new_columns;
@@ -139,11 +138,11 @@ class Staff_Directory {
 	static function set_staff_category_columns() {
 		$new_columns = array(
 			'cb'          => '<input type="checkbox" />',
-			'name'        => __( 'Name' ),
-			'id'          => __( 'ID' ),
-			'description' => __( 'Description' ),
-			'slug'        => __( 'Slug' ),
-			'posts'       => __( 'Posts' )
+			'name'        => __( 'Name', 'staff-directory' ),
+			'id'          => __( 'ID', 'staff-directory' ),
+			'description' => __( 'Description', 'staff-directory' ),
+			'slug'        => __( 'Slug', 'staff-directory' ),
+			'posts'       => __( 'Posts', 'staff-directory' )
 		);
 
 		return $new_columns;
@@ -188,7 +187,7 @@ class Staff_Directory {
 	}
 
 	static function add_staff_custom_meta_boxes() {
-		add_meta_box( 'staff-meta-box', __( 'Staff Details' ), array(
+		add_meta_box( 'staff-meta-box', __( 'Staff Details', 'staff-directory' ), array(
 			'Staff_Directory',
 			'staff_meta_box_output'
 		), 'staff', 'normal', 'high' );

--- a/classes/staff-directory.php
+++ b/classes/staff-directory.php
@@ -9,6 +9,7 @@ class Staff_Directory {
 	static function register_post_types() {
 		add_action( 'init', array( 'Staff_Directory', 'create_post_types' ) );
 		add_action( 'init', array( 'Staff_Directory', 'create_staff_taxonomies' ) );
+		add_action( 'init', array( 'Staff_Directory', 'load_textdomain' ) );
 		add_filter( "manage_edit-staff_columns", array( 'Staff_Directory', 'set_staff_admin_columns' ) );
 		add_filter( "manage_staff_posts_custom_column", array(
 			'Staff_Directory',
@@ -75,6 +76,10 @@ class Staff_Directory {
 				'hierarchical' => true
 			),
 		) );
+	}
+
+	static function load_textdomain() {
+		load_plugin_textdomain('staff-directory', false, basename(dirname(__FILE__)) . '/languages/');
 	}
 
     static function load_profile_template($original){

--- a/languages/staff-directory.pot
+++ b/languages/staff-directory.pot
@@ -1,0 +1,78 @@
+# Copyright (C) 2016 
+# This file is distributed under the same license as the  package.
+msgid ""
+msgstr ""
+"Project-Id-Version:  \n"
+"Report-Msgid-Bugs-To: http://wordpress.org/tag/\n"
+"POT-Creation-Date: 2016-12-02 13:26:01+00:00\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2016-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+
+msgid "Staff"
+msgstr ""
+
+msgctxt "taxonomy general name"
+msgid "Staff Category"
+msgstr ""
+
+msgctxt "taxonomy singular name"
+msgid "staff-category"
+msgstr ""
+
+msgid "Search Staff Categories"
+msgstr ""
+
+msgid "All Staff Categories"
+msgstr ""
+
+msgid "Parent Staff Category"
+msgstr ""
+
+msgid "Parent Staff Category:"
+msgstr ""
+
+msgid "Edit Staff Category"
+msgstr ""
+
+msgid "Update Staff Category"
+msgstr ""
+
+msgid "Add New Staff Category"
+msgstr ""
+
+msgid "New Staff Category Name"
+msgstr ""
+
+msgid "Staff Categories"
+msgstr ""
+
+msgid "Title"
+msgstr ""
+
+msgid "ID"
+msgstr ""
+
+msgid "Featured Image"
+msgstr ""
+
+msgid "Date"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Description"
+msgstr ""
+
+msgid "Slug"
+msgstr ""
+
+msgid "Posts"
+msgstr ""
+
+msgid "Staff Details"
+msgstr ""

--- a/staff-directory.php
+++ b/staff-directory.php
@@ -4,6 +4,8 @@ Plugin Name: Staff Directory
 Plugin URI: https://wordpress.org/plugins/staff-directory/
 Description: Allows Wordpress to keep track of your staff directory for your website. Good for churches, small companies, etc.
 Version: 1.1.1
+Text Domain: staff-directory
+Domain Path: /languages
 Author: Adam Tootle
 Author URI: http://www.adamtootle.com
 */

--- a/staff-directory.php
+++ b/staff-directory.php
@@ -17,6 +17,7 @@ define( 'STAFF_DIRECTORY_TABLE', $wpdb->prefix . 'staff_directory' );
 define( 'STAFF_TEMPLATES', $wpdb->prefix . 'staff_directory_templates' );
 define( 'STAFF_PHOTOS_DIRECTORY', WP_CONTENT_DIR . "/uploads/staff-photos/" );
 define( 'STAFF_LIST_TEMPLATES', plugin_dir_path(__FILE__) . "templates/" );
+define( 'STAFF_LANGUAGES_DIRECTORY', basename(dirname(__FILE__)) . '/languages/' );
 
 require_once( dirname( __FILE__ ) . '/classes/staff-directory-settings.php' );
 
@@ -25,6 +26,8 @@ Staff_Directory_Settings::setup_defaults();
 require_once( dirname( __FILE__ ) . '/classes/staff-directory.php' );
 require_once( dirname( __FILE__ ) . '/classes/staff-directory-shortcode.php' );
 require_once( dirname( __FILE__ ) . '/classes/staff-directory-admin.php' );
+
+add_action( 'init', array( 'Staff_Directory', 'load_textdomain' ) );
 
 Staff_Directory::register_post_types();
 Staff_Directory::set_default_meta_fields_if_necessary();


### PR DESCRIPTION
This pull request adds internationalization support as described in [this official document](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/).

Such a feature will unlock to the users the ability to give new translation using the [plugin's GlotPress section](https://translate.wordpress.org/projects/wp-plugins/staff-directory).

_Of course it's only a starter, to fully support internationalization you'll have to follow the instructions and use the GetText macros all over the source files instead of hardcoded translations._